### PR TITLE
PAR-9: adds upload-button functionality with drag&drop

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -10,9 +10,10 @@
 
     <div fxLayout="row" fxLayoutAlign="space-evenly start">
         <app-template-button
-            buttonText="Left button"
-            buttonIcon="lightbulb"
-            (click)="uploadFile()"
+            buttonText="Upload"
+            buttonIcon="upload"
+            (buttonAction)="openFileSelector()"
+            (dropAction)="dropFiles($event)"
         ></app-template-button>
         <mat-form-field appearance="outline" class="textarea">
             <mat-label>Source file</mat-label>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -11,13 +11,9 @@ describe('AppComponent', () => {
     const mockUploadService = {
         get upload$(): any {
             return {
-                subscribe: () => {
-                    return {
-                        unsubscribe: () => {
-                            return null;
-                        },
-                    };
-                },
+                subscribe: () => ({
+                    unsubscribe: jest.fn(),
+                }),
             };
         },
     };

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -8,6 +8,20 @@ import { ParserService } from './services/parser.service';
 import { UploadService } from './services/upload/upload.service';
 
 describe('AppComponent', () => {
+    const mockUploadService = {
+        get upload$(): any {
+            return {
+                subscribe: () => {
+                    return {
+                        unsubscribe: () => {
+                            return null;
+                        },
+                    };
+                },
+            };
+        },
+    };
+
     beforeEach(async () => {
         await TestBed.configureTestingModule({
             imports: [RouterTestingModule],
@@ -15,7 +29,7 @@ describe('AppComponent', () => {
             providers: [
                 { provide: ParserService, useValue: {} },
                 { provide: DisplayService, useValue: {} },
-                { provide: UploadService, useValue: {} },
+                { provide: UploadService, useValue: mockUploadService },
             ],
             schemas: [CUSTOM_ELEMENTS_SCHEMA],
         }).compileComponents();

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -15,21 +15,26 @@ export class AppComponent implements OnDestroy {
     public textareaFc: FormControl;
 
     private _sub: Subscription;
+    private _fileSub: Subscription;
 
     constructor(
         private _parserService: ParserService,
         private _displayService: DisplayService,
-        private _uploadService: UploadService
+        private _uploadService: UploadService,
     ) {
         this.textareaFc = new FormControl();
         this._sub = this.textareaFc.valueChanges
             .pipe(debounceTime(400))
             .subscribe((val) => this.processSourceChange(val));
         this.textareaFc.setValue(`hello world`);
+
+        this._fileSub = this._uploadService.upload$
+            .subscribe((content) => this.processNewSource(content));
     }
 
     ngOnDestroy(): void {
         this._sub.unsubscribe();
+        this._fileSub.unsubscribe();
     }
 
     private processSourceChange(newSource: string) {
@@ -37,15 +42,27 @@ export class AppComponent implements OnDestroy {
         if (!result) {
             return;
         }
-        this._displayService.display(result);
+
+        this._displayService.updateCurrentRun(result);
     }
 
-    async uploadFile(): Promise<void> {
-        const content = await this._uploadService.uploadFile();
-        if (!content) {
+    private processNewSource(newSource: string) {
+        const result = this._parserService.parse(newSource);
+        if (!result) {
             return;
         }
 
-        this.textareaFc.setValue(content);
+        this._displayService.registerRun(result);
+        this.textareaFc.setValue(newSource, {emitEvent: false});
+    }
+
+    public openFileSelector() {
+        this._uploadService.openFileSelector();
+    }
+
+    public dropFiles(event: DragEvent): void{
+        if (event.dataTransfer?.files) {
+            this._uploadService.uploadFiles(event.dataTransfer.files);
+        }
     }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -20,7 +20,7 @@ export class AppComponent implements OnDestroy {
     constructor(
         private _parserService: ParserService,
         private _displayService: DisplayService,
-        private _uploadService: UploadService,
+        private _uploadService: UploadService
     ) {
         this.textareaFc = new FormControl();
         this._sub = this.textareaFc.valueChanges
@@ -28,8 +28,9 @@ export class AppComponent implements OnDestroy {
             .subscribe((val) => this.processSourceChange(val));
         this.textareaFc.setValue(`hello world`);
 
-        this._fileSub = this._uploadService.upload$
-            .subscribe((content) => this.processNewSource(content));
+        this._fileSub = this._uploadService.upload$.subscribe((content) =>
+            this.processNewSource(content)
+        );
     }
 
     ngOnDestroy(): void {
@@ -37,7 +38,7 @@ export class AppComponent implements OnDestroy {
         this._fileSub.unsubscribe();
     }
 
-    private processSourceChange(newSource: string) {
+    private processSourceChange(newSource: string): void {
         const result = this._parserService.parse(newSource);
         if (!result) {
             return;
@@ -46,21 +47,21 @@ export class AppComponent implements OnDestroy {
         this._displayService.updateCurrentRun(result);
     }
 
-    private processNewSource(newSource: string) {
+    private processNewSource(newSource: string): void {
         const result = this._parserService.parse(newSource);
         if (!result) {
             return;
         }
 
         this._displayService.registerRun(result);
-        this.textareaFc.setValue(newSource, {emitEvent: false});
+        this.textareaFc.setValue(newSource, { emitEvent: false });
     }
 
-    public openFileSelector() {
+    public openFileSelector(): void {
         this._uploadService.openFileSelector();
     }
 
-    public dropFiles(event: DragEvent): void{
+    public dropFiles(event: DragEvent): void {
         if (event.dataTransfer?.files) {
             this._uploadService.uploadFiles(event.dataTransfer.files);
         }

--- a/src/app/classes/diagram/run.ts
+++ b/src/app/classes/diagram/run.ts
@@ -24,6 +24,10 @@ export class Run {
     addArc(arc: Arc): void {
         this._arcs.push(arc);
     }
+
+    isEmpty(): boolean {
+        return this.arcs.length + this.elements.length === 0;
+    }
 }
 
 export type Arc = {

--- a/src/app/components/display/display.component.ts
+++ b/src/app/components/display/display.component.ts
@@ -15,16 +15,16 @@ export class DisplayComponent implements OnDestroy {
     @ViewChild('drawingArea') drawingArea: ElementRef<SVGElement> | undefined;
 
     private _sub: Subscription;
-    private _diagram: Run | undefined;
+    private _currentRun: Run | undefined;
 
     constructor(
         private _layoutService: LayoutService,
         private _svgService: SvgService,
         private _displayService: DisplayService
     ) {
-        this._sub = this._displayService.diagram$.subscribe((diagram) => {
-            this._diagram = diagram;
-            this._layoutService.layout(this._diagram);
+        this._sub = this._displayService.currentRun$.subscribe((currentRun) => {
+            this._currentRun = currentRun;
+            this._layoutService.layout(this._currentRun);
             this.draw();
         });
     }
@@ -41,7 +41,7 @@ export class DisplayComponent implements OnDestroy {
 
         this.clearDrawingArea();
         const elements = this._svgService.createSvgElements(
-            this._displayService.diagram
+            this._displayService.currentRun
         );
         for (const element of elements) {
             this.drawingArea.nativeElement.appendChild(element);

--- a/src/app/components/template-button/template-button.component.html
+++ b/src/app/components/template-button/template-button.component.html
@@ -7,6 +7,9 @@
         (click)="processMouseClick($event)"
         (mouseenter)="hoverStart($event)"
         (mouseleave)="hoverEnd($event)"
+        (drop)="processDrop($event)"
+        (dragover)="dragStart($event)"
+        (dragleave)="dragEnd($event)"
     >
         <mat-icon class="larger-icon">
             {{ buttonIcon }}

--- a/src/app/components/template-button/template-button.component.scss
+++ b/src/app/components/template-button/template-button.component.scss
@@ -7,8 +7,16 @@
     margin-top: 14px;
 }
 
-.mouse-hover {
+.interactive-square * {
+    pointer-events: none;
+}
+
+.mouse-hover:not(.drag-hover) {
     border-color: black;
+}
+
+.drag-hover {
+    border-color: green;
 }
 
 .larger-icon {
@@ -18,6 +26,7 @@
     color: dimgrey;
 }
 
-.mouse-hover .larger-icon {
+.mouse-hover .larger-icon, .drag-hover .larger-icon {
     color: black;
 }
+

--- a/src/app/components/template-button/template-button.component.ts
+++ b/src/app/components/template-button/template-button.component.ts
@@ -8,8 +8,8 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 export class TemplateButtonComponent {
     @Input() buttonText: string | undefined;
     @Input() buttonIcon: string | undefined;
-    @Output() buttonAction: EventEmitter<any> = new EventEmitter();
-    @Output() dropAction: EventEmitter<any> = new EventEmitter();
+    @Output() buttonAction = new EventEmitter<void>();
+    @Output() dropAction = new EventEmitter<DragEvent>();
 
     prevent(e: Event): void {
         e.preventDefault();
@@ -29,9 +29,7 @@ export class TemplateButtonComponent {
     }
 
     processMouseClick(e: MouseEvent): void {
-        if (this.buttonAction) {
-            this.buttonAction.emit();
-        }
+        this.buttonAction.emit();
     }
 
     processDrop(e: DragEvent): void {
@@ -39,9 +37,7 @@ export class TemplateButtonComponent {
         const target = e.target as HTMLElement;
         target.classList.remove('drag-hover');
 
-        if (this.dropAction) {
-            this.dropAction.emit(e);
-        }
+        this.dropAction.emit(e);
     }
 
     dragStart(e: DragEvent): void {

--- a/src/app/components/template-button/template-button.component.ts
+++ b/src/app/components/template-button/template-button.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 @Component({
     selector: 'app-template-button',
@@ -8,6 +8,8 @@ import { Component, Input } from '@angular/core';
 export class TemplateButtonComponent {
     @Input() buttonText: string | undefined;
     @Input() buttonIcon: string | undefined;
+    @Output() buttonAction: EventEmitter<any> = new EventEmitter();
+    @Output() dropAction: EventEmitter<any> = new EventEmitter();
 
     prevent(e: Event): void {
         e.preventDefault();
@@ -27,6 +29,30 @@ export class TemplateButtonComponent {
     }
 
     processMouseClick(e: MouseEvent): void {
-        console.log(`Template button "${this.buttonText}" clicked`, e);
+        if(this.buttonAction) {
+            this.buttonAction.emit()
+        }
+    }
+
+    processDrop(e: DragEvent) {
+        this.prevent(e);
+        const target = e.target as HTMLElement;
+        target.classList.remove('drag-hover');
+
+        if(this.dropAction) {
+            this.dropAction.emit(e);
+        }
+    }
+
+    dragStart(e: DragEvent) {
+        this.prevent(e);
+        const target = e.target as HTMLElement;
+        target.classList.add('drag-hover');
+    }
+
+    dragEnd(e: DragEvent) {
+        this.prevent(e);
+        const target = e.target as HTMLElement;
+        target.classList.remove('drag-hover');
     }
 }

--- a/src/app/components/template-button/template-button.component.ts
+++ b/src/app/components/template-button/template-button.component.ts
@@ -29,28 +29,28 @@ export class TemplateButtonComponent {
     }
 
     processMouseClick(e: MouseEvent): void {
-        if(this.buttonAction) {
-            this.buttonAction.emit()
+        if (this.buttonAction) {
+            this.buttonAction.emit();
         }
     }
 
-    processDrop(e: DragEvent) {
+    processDrop(e: DragEvent): void {
         this.prevent(e);
         const target = e.target as HTMLElement;
         target.classList.remove('drag-hover');
 
-        if(this.dropAction) {
+        if (this.dropAction) {
             this.dropAction.emit(e);
         }
     }
 
-    dragStart(e: DragEvent) {
+    dragStart(e: DragEvent): void {
         this.prevent(e);
         const target = e.target as HTMLElement;
         target.classList.add('drag-hover');
     }
 
-    dragEnd(e: DragEvent) {
+    dragEnd(e: DragEvent): void {
         this.prevent(e);
         const target = e.target as HTMLElement;
         target.classList.remove('drag-hover');

--- a/src/app/services/display.service.ts
+++ b/src/app/services/display.service.ts
@@ -9,8 +9,13 @@ import { Run } from '../classes/diagram/run';
 export class DisplayService implements OnDestroy {
     private _diagram$: BehaviorSubject<Run>;
 
+    private readonly _runs: Run[] = [];
+    private _currentRun: Run;
+
     constructor() {
-        this._diagram$ = new BehaviorSubject<Run>(new Run());
+        this._currentRun = new Run();
+        this.runs.push(this.currentRun);
+        this._diagram$ = new BehaviorSubject<Run>(this.currentRun);
     }
 
     ngOnDestroy(): void {
@@ -25,7 +30,67 @@ export class DisplayService implements OnDestroy {
         return this._diagram$.getValue();
     }
 
-    public display(net: Run): void {
+    private display(net: Run): void {
         this._diagram$.next(net);
+    }
+
+    public get currentRun(): Run{
+        return this._currentRun;
+    }
+
+    public get runs(): Run[] {
+        return this._runs;
+    }
+
+    public set currentRun(value: Run)  {
+        this._currentRun = value;
+        this.display(this.currentRun)
+    }
+
+    public addEmptyRun(): void {
+        this.registerRun(new Run());
+    }
+ 
+    public registerRun(run: Run): void {
+        //add run or update current run if empty
+        if(this.currentRun.isEmpty()) {
+            this.updateCurrentRun(run);
+        } else {
+            this.runs.push(run);
+        }
+
+        this.currentRun = run;
+    }
+
+    public getRunIndex(run: Run): number {
+        return this.runs.indexOf(run);
+    }
+
+    public updateCurrentRun(run: Run): void {
+        const index = this.getRunIndex(this.currentRun);
+        this.runs[index] = run;
+        this.currentRun = run;
+    }
+
+    public removeRun(run: Run): void {
+        const index = this.getRunIndex(run);
+        if (index > -1) {
+            this.runs.splice(index, 1);
+        }
+
+        if(this.runs.length > 0) {
+            this.currentRun = this.runs[Math.max(index-1, 0)]; //set previous run as active
+        }else {
+            this.addEmptyRun(); //create new empty run
+        }
+    }
+
+    public removeCurrentRun(): void {
+        this.removeRun(this.currentRun);
+    }
+
+    public clearRuns(): void {
+        this.runs.splice(0, this.runs.length);
+        this.addEmptyRun();
     }
 }

--- a/src/app/services/display.service.ts
+++ b/src/app/services/display.service.ts
@@ -34,26 +34,22 @@ export class DisplayService implements OnDestroy {
         this._diagram$.next(net);
     }
 
-    public get currentRun(): Run{
-        return this._currentRun;
-    }
-
     public get runs(): Run[] {
         return this._runs;
     }
 
-    public set currentRun(value: Run)  {
+    public set currentRun(value: Run) {
         this._currentRun = value;
-        this.display(this.currentRun)
+        this.display(this.currentRun);
     }
 
     public addEmptyRun(): void {
         this.registerRun(new Run());
     }
- 
+
     public registerRun(run: Run): void {
         //add run or update current run if empty
-        if(this.currentRun.isEmpty()) {
+        if (this.currentRun.isEmpty()) {
             this.updateCurrentRun(run);
         } else {
             this.runs.push(run);
@@ -78,9 +74,9 @@ export class DisplayService implements OnDestroy {
             this.runs.splice(index, 1);
         }
 
-        if(this.runs.length > 0) {
-            this.currentRun = this.runs[Math.max(index-1, 0)]; //set previous run as active
-        }else {
+        if (this.runs.length > 0) {
+            this.currentRun = this.runs[Math.max(index - 1, 0)]; //set previous run as active
+        } else {
             this.addEmptyRun(); //create new empty run
         }
     }

--- a/src/app/services/display.service.ts
+++ b/src/app/services/display.service.ts
@@ -7,40 +7,28 @@ import { Run } from '../classes/diagram/run';
     providedIn: 'root',
 })
 export class DisplayService implements OnDestroy {
-    private _diagram$: BehaviorSubject<Run>;
+    private _currentRun$: BehaviorSubject<Run>;
 
     private readonly _runs: Run[] = [];
-    private _currentRun: Run;
 
     constructor() {
-        this._currentRun = new Run();
-        this.runs.push(this.currentRun);
-        this._diagram$ = new BehaviorSubject<Run>(this.currentRun);
+        this.runs.push(new Run());
+        this._currentRun$ = new BehaviorSubject<Run>(this.runs[0]);
     }
 
     ngOnDestroy(): void {
-        this._diagram$.complete();
+        this._currentRun$.complete();
     }
 
-    public get diagram$(): Observable<Run> {
-        return this._diagram$.asObservable();
-    }
-
-    public get diagram(): Run {
-        return this._diagram$.getValue();
-    }
-
-    private display(net: Run): void {
-        this._diagram$.next(net);
+    public get currentRun$(): Observable<Run> {
+        return this._currentRun$.asObservable();
     }
 
     public get currentRun(): Run {
-        return this._currentRun;
+        return this._currentRun$.getValue();
     }
-
-    public set currentRun(value: Run) {
-        this._currentRun = value;
-        this.display(this.currentRun);
+    private display(net: Run): void {
+        this._currentRun$.next(net);
     }
 
     public get runs(): Run[] {
@@ -57,9 +45,8 @@ export class DisplayService implements OnDestroy {
             this.updateCurrentRun(run);
         } else {
             this.runs.push(run);
+            this.display(run);
         }
-
-        this.currentRun = run;
     }
 
     public getRunIndex(run: Run): number {
@@ -69,7 +56,7 @@ export class DisplayService implements OnDestroy {
     public updateCurrentRun(run: Run): void {
         const index = this.getRunIndex(this.currentRun);
         this.runs[index] = run;
-        this.currentRun = run;
+        this.display(run);
     }
 
     public removeRun(run: Run): void {
@@ -79,7 +66,7 @@ export class DisplayService implements OnDestroy {
         }
 
         if (this.runs.length > 0) {
-            this.currentRun = this.runs[Math.max(index - 1, 0)]; //set previous run as active
+            this.display(this.runs[Math.max(index - 1, 0)]); //set previous run as active
         } else {
             this.addEmptyRun(); //create new empty run
         }

--- a/src/app/services/display.service.ts
+++ b/src/app/services/display.service.ts
@@ -34,13 +34,17 @@ export class DisplayService implements OnDestroy {
         this._diagram$.next(net);
     }
 
-    public get runs(): Run[] {
-        return this._runs;
+    public get currentRun(): Run {
+        return this._currentRun;
     }
 
     public set currentRun(value: Run) {
         this._currentRun = value;
         this.display(this.currentRun);
+    }
+
+    public get runs(): Run[] {
+        return this._runs;
     }
 
     public addEmptyRun(): void {

--- a/src/app/services/upload/upload.service.ts
+++ b/src/app/services/upload/upload.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, OnDestroy } from '@angular/core';
 import { ToastrService } from 'ngx-toastr';
 import { Observable, Subject } from 'rxjs';
 
@@ -9,7 +9,7 @@ const allowedExtensions = ['ps'];
 @Injectable({
     providedIn: 'root',
 })
-export class UploadService {
+export class UploadService implements OnDestroy {
     private _upload$: Subject<string>;
 
     constructor(private toastr: ToastrService) {
@@ -25,9 +25,9 @@ export class UploadService {
     }
 
     public checkFiles(files: FileList): boolean {
-        var check: boolean = true;
+        let check = true;
 
-        Array.from(files).forEach(file => {
+        Array.from(files).forEach((file) => {
             if (!fileExtensionIsValid(file.name)) {
                 check = false;
                 this.toastr.error(
@@ -40,13 +40,19 @@ export class UploadService {
         return check;
     }
 
-    public openFileSelector() {
-        var fileUpload = document.createElement("input");
-        fileUpload.setAttribute("type", "file");
-        fileUpload.setAttribute("multiple", "multiple");
-        fileUpload.setAttribute("accept", allowedExtensions.map(e => "." + e).join(","));
+    public openFileSelector(): void {
+        const fileUpload = document.createElement('input');
+        fileUpload.setAttribute('type', 'file');
+        fileUpload.setAttribute('multiple', 'multiple');
+        fileUpload.setAttribute(
+            'accept',
+            allowedExtensions.map((e) => '.' + e).join(',')
+        );
         fileUpload.onchange = (event) => {
-            if (event.target instanceof HTMLInputElement && event.target?.files) {
+            if (
+                event.target instanceof HTMLInputElement &&
+                event.target?.files
+            ) {
                 this.uploadFiles(event.target.files);
             }
         };
@@ -54,13 +60,13 @@ export class UploadService {
         fileUpload.click();
     }
 
-    public uploadFiles(files: FileList) {
+    public uploadFiles(files: FileList): void {
         if (!this.checkFiles(files)) {
             return;
         }
 
-        Array.from(files).forEach(file => {
-            var reader = new FileReader();
+        Array.from(files).forEach((file) => {
+            const reader = new FileReader();
 
             reader.onload = () => {
                 const content: string = reader.result as string;


### PR DESCRIPTION
Der bisherige Upload-Service wurde etwas angepasst. Es kann eine oder mehrere Dateien gleichzeitig hochgeladen werden. Über einen Observable wird der Inhalt jeder Datei zurückgegeben und der Run kann geparst werden.

Im DisplaySerivce habe ich rudimentär das Verwalten mehrerer Runs hinzugefügt, damit beim Upload mehrere Dateien alle Runs erstmal irgendwo hinterlegt werden können.
Initial wird ein leerer Run erstellt. Beim Update des Textfeldes wird der Inhalt neu geparst und der Run aktualisiert. Beim Upload wird jede Datei geparst und anschließend der Run hinzugefügt. Der letzte Run wird aktuell immer angezeigt. Die importierten Runs können auch über das Textfeld bearbeitet werden.