### PR TITLE
displays run validation at the text field + manage multiple runs

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -103,7 +103,7 @@
                 </button>
             </div>
             <button
-                *ngIf="isRunValid === Valid.Warn"
+                *ngIf="runValidationStatus === 'warn'"
                 class="button_resolve"
                 color="accent"
                 matSuffix

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -52,6 +52,75 @@
                 cdkAutosizeMaxRows="20"
                 [formControl]="textareaFc"
             ></textarea>
+            <mat-divider></mat-divider>
+            <div fxLayout="row" fxLayoutAlign="space-evenly start">
+                <span class="run_info">{{ displayRunCount() }}</span>
+                <button
+                    mat-icon-button
+                    aria-label="Previous run"
+                    matTooltip="Previous run"
+                    [disabled]="!hasPreviousRun()"
+                    (click)="previousRun()"
+                >
+                    <mat-icon>navigate_before</mat-icon>
+                </button>
+                <button
+                    mat-icon-button
+                    aria-label="Next run"
+                    matTooltip="Next run"
+                    [disabled]="!hasNextRun()"
+                    (click)="nextRun()"
+                >
+                    <mat-icon>navigate_next</mat-icon>
+                </button>
+            </div>
+            <div fxLayout="row" fxLayoutAlign="space-evenly start">
+                <button
+                    mat-icon-button
+                    aria-label="Delete current run"
+                    matTooltip="Delete current run"
+                    color="warn"
+                    [disabled]="
+                        isCurrentRunEmpty() &&
+                        !hasPreviousRun() &&
+                        !hasNextRun()
+                    "
+                    (click)="removeRun()"
+                >
+                    <mat-icon>delete_forever</mat-icon>
+                </button>
+                <button
+                    mat-icon-button
+                    aria-label="Add empty run"
+                    matTooltip="Add empty run"
+                    color="primary"
+                    [disabled]="isCurrentRunEmpty()"
+                    (click)="addRun()"
+                >
+                    <mat-icon>add_circle</mat-icon>
+                </button>
+                <button
+                    mat-icon-button
+                    aria-label="Reset runs"
+                    matTooltip="Reset runs"
+                    color="warn"
+                    (click)="reset()"
+                >
+                    <mat-icon>restart_alt</mat-icon>
+                </button>
+            </div>
+            <button
+                *ngIf="isRunValid === Valid.Warn"
+                class="button_resolve"
+                color="accent"
+                matSuffix
+                mat-icon-button
+                aria-label="Resolve warnings"
+                matTooltip="Resolve warnings"
+                (click)="resolveWarnings()"
+            >
+                <mat-icon>auto_fix_high</mat-icon>
+            </button>
         </mat-form-field>
         <app-template-button
             buttonText="Right button"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -26,24 +26,17 @@
                 fxLayoutAlign="space-between"
             >
                 <span>Source file</span>
-                <mat-icon
-                    *ngIf="isRunValid === Valid.Success"
-                    class="color_success"
-                >
-                    check_circle
-                </mat-icon>
-                <mat-icon
-                    *ngIf="isRunValid === Valid.Warn"
-                    class="color_warning"
-                >
-                    warning_amber
-                </mat-icon>
-                <mat-icon
-                    *ngIf="isRunValid === Valid.Error"
-                    class="color_error"
-                >
-                    error_outline
-                </mat-icon>
+                <ng-container [ngSwitch]="runValidationStatus">
+                    <mat-icon *ngSwitchCase="'success'" class="color_success">
+                        check_circle
+                    </mat-icon>
+                    <mat-icon *ngSwitchCase="'warn'" class="color_warning">
+                        warning_amber
+                    </mat-icon>
+                    <mat-icon *ngSwitchCase="'error'" class="color_error">
+                        error_outline
+                    </mat-icon>
+                </ng-container>
             </mat-label>
             <textarea
                 matInput

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -15,8 +15,36 @@
             (buttonAction)="openFileSelector()"
             (dropAction)="dropFiles($event)"
         ></app-template-button>
-        <mat-form-field appearance="outline" class="textarea">
-            <mat-label>Source file</mat-label>
+        <mat-form-field
+            appearance="outline"
+            class="textarea"
+            [matTooltip]="runHint"
+        >
+            <mat-label
+                class="source_label"
+                fxLayout="row"
+                fxLayoutAlign="space-between"
+            >
+                <span>Source file</span>
+                <mat-icon
+                    *ngIf="isRunValid === Valid.Success"
+                    class="color_success"
+                >
+                    check_circle
+                </mat-icon>
+                <mat-icon
+                    *ngIf="isRunValid === Valid.Warn"
+                    class="color_warning"
+                >
+                    warning_amber
+                </mat-icon>
+                <mat-icon
+                    *ngIf="isRunValid === Valid.Error"
+                    class="color_error"
+                >
+                    error_outline
+                </mat-icon>
+            </mat-label>
             <textarea
                 matInput
                 cdkTextareaAutosize

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -31,3 +31,28 @@ hr {
     margin-bottom: 30px;
     width: 100%;
 }
+
+.source_label mat-icon {
+    font-size: 25px;
+    padding-right: 10px;
+}
+
+mat-icon.color_success { 
+    color: #4CAF50;
+}
+
+mat-icon.color_warning {
+    color: #ff9800;
+}
+
+mat-icon.color_error {
+    color: #f44336;
+}
+
+.mat-tooltip {
+    white-space: pre-line;
+}
+
+::ng-deep .mat-tooltip {
+    white-space: pre-line;
+}

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -38,7 +38,7 @@ hr {
 }
 
 mat-icon.color_success { 
-    color: #4CAF50;
+    color: var(--success-color);
 }
 
 mat-icon.color_warning {

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -56,3 +56,9 @@ mat-icon.color_error {
 ::ng-deep .mat-tooltip {
     white-space: pre-line;
 }
+
+.button_resolve {
+    position: absolute;
+    right: 0px;
+    bottom: 8px;
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -67,7 +67,7 @@ export class AppComponent implements OnDestroy {
         run: Run | null,
         errors: Set<string> = new Set<string>()
     ): void {
-        this._runHint = [...errors, ...(run ? run.warnings : [])].join('\n');
+        this.runHint = [...errors, ...(run ? run.warnings : [])].join('\n');
 
         if (!run || errors.size > 0) {
             this.textareaFc.setErrors({ 'invalid run': true });
@@ -77,7 +77,7 @@ export class AppComponent implements OnDestroy {
         } else if (!run.isEmpty()) {
             this.runValidationStatus = 'success';
         } else {
-            this._isRunValid = null;
+            this.runValidationStatus = null;
         }
     }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -15,12 +15,11 @@ import { UploadService } from './services/upload/upload.service';
 })
 export class AppComponent implements OnDestroy {
     public textareaFc: FormControl;
-    public Valid = Valid;
 
     private _sub: Subscription;
     private _fileSub: Subscription;
-    private _isRunValid: Valid | null = null;
-    private _runHint = '';
+    runValidationStatus: Valid | null = null;
+    runHint = '';
 
     constructor(
         private _parserService: ParserService,
@@ -72,22 +71,14 @@ export class AppComponent implements OnDestroy {
 
         if (!run || errors.size > 0) {
             this.textareaFc.setErrors({ 'invalid run': true });
-            this._isRunValid = Valid.Error;
+            this.runValidationStatus = 'error';
         } else if (run.warnings.size > 0) {
-            this._isRunValid = Valid.Warn;
+            this.runValidationStatus = 'warn';
         } else if (!run.isEmpty()) {
-            this._isRunValid = Valid.Success;
+            this.runValidationStatus = 'success';
         } else {
             this._isRunValid = null;
         }
-    }
-
-    get isRunValid(): number | null {
-        return this._isRunValid;
-    }
-
-    get runHint(): string {
-        return this._runHint;
     }
 
     public openFileSelector(): void {
@@ -162,8 +153,4 @@ export class AppComponent implements OnDestroy {
     }
 }
 
-export enum Valid {
-    Error,
-    Warn,
-    Success,
-}
+type Valid = 'error' | 'warn' | 'success';

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
+import { MatDividerModule } from '@angular/material/divider';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
@@ -31,6 +32,7 @@ import { TemplateButtonComponent } from './components/template-button/template-b
         MatButtonModule,
         MatIconModule,
         MatTooltipModule,
+        MatDividerModule,
         ReactiveFormsModule,
         ToastrModule.forRoot({
             preventDuplicates: true,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,6 +5,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ToastrModule } from 'ngx-toastr';
@@ -29,8 +30,11 @@ import { TemplateButtonComponent } from './components/template-button/template-b
         MatInputModule,
         MatButtonModule,
         MatIconModule,
+        MatTooltipModule,
         ReactiveFormsModule,
-        ToastrModule.forRoot(),
+        ToastrModule.forRoot({
+            preventDuplicates: true,
+        }),
     ],
     providers: [],
     bootstrap: [AppComponent],

--- a/src/app/classes/diagram/element.ts
+++ b/src/app/classes/diagram/element.ts
@@ -1,8 +1,12 @@
+import { Arc } from './run';
+
 export class Element {
     private _x: number;
     private _y: number;
     private _label: string;
     private _svgElement: SVGElement | undefined;
+    private _incomingArcs: Arc[] = [];
+    private _outgoingArcs: Arc[] = [];
 
     constructor(label: string) {
         this._x = 0;
@@ -32,6 +36,27 @@ export class Element {
 
     set label(value: string) {
         this._label = value;
+    }
+
+    get incomingArcs(): Arc[] {
+        return this._incomingArcs;
+    }
+
+    get outogingArcs(): Arc[] {
+        return this._outgoingArcs;
+    }
+
+    public addIncomingArc(a: Arc): void {
+        this.incomingArcs.push(a);
+    }
+
+    public addOutgoingArc(a: Arc): void {
+        this.outogingArcs.push(a);
+    }
+
+    public resetArcs(): void {
+        this._incomingArcs.splice(0, this._incomingArcs.length);
+        this._outgoingArcs.splice(0, this._outgoingArcs.length);
     }
 
     public registerSvg(svg: SVGElement): void {

--- a/src/app/classes/diagram/run.ts
+++ b/src/app/classes/diagram/run.ts
@@ -123,6 +123,6 @@ export class Run {
 export type Arc = {
     source: string;
     target: string;
-    sourceEl: Element | null;
-    targetEl: Element | null;
+    sourceEl?: Element;
+    targetEl?: Element;
 };

--- a/src/app/classes/diagram/run.ts
+++ b/src/app/classes/diagram/run.ts
@@ -4,6 +4,7 @@ export class Run {
     private readonly _arcs: Array<Arc>;
     private readonly _elements: Array<Element>;
     private readonly _warnings: Set<string>;
+    private _text = '';
 
     constructor() {
         this._arcs = [];
@@ -21,6 +22,14 @@ export class Run {
 
     get warnings(): Set<string> {
         return this._warnings;
+    }
+
+    get text(): string {
+        return this._text;
+    }
+
+    setText(text: string): void {
+        this._text = text;
     }
 
     addWarning(warning: string): void {
@@ -58,6 +67,26 @@ export class Run {
     isEmpty(): boolean {
         return this.arcs.length + this.elements.length === 0;
     }
+
+    /**
+     * resolve warnings (removes duplicates and invalid arcs)
+     */
+    resolveWarnings(): void {
+        const lines = ['.type ps'];
+        lines.push('.transitions');
+        this.elements.forEach((e) => {
+            lines.push(e.label);
+        });
+
+        lines.push('.arcs');
+        this.arcs.forEach((e) => {
+            if (e.sourceEl && e.targetEl) lines.push(e.source + ' ' + e.target);
+        });
+
+        this.setText(lines.join('\n'));
+        this.clearWarnings();
+    }
+
     /**
      * set reference from arcs to transitions and vice versa
      * @returns all references found?

--- a/src/app/classes/diagram/run.ts
+++ b/src/app/classes/diagram/run.ts
@@ -3,10 +3,12 @@ import { Element } from './element';
 export class Run {
     private readonly _arcs: Array<Arc>;
     private readonly _elements: Array<Element>;
+    private readonly _warnings: Set<string>;
 
     constructor() {
         this._arcs = [];
         this._elements = [];
+        this._warnings = new Set<string>();
     }
 
     get elements(): Array<Element> {
@@ -17,34 +19,81 @@ export class Run {
         return this._arcs;
     }
 
-    addElement(element: Element): void {
+    get warnings(): Set<string> {
+        return this._warnings;
+    }
+
+    addWarning(warning: string): void {
+        this._warnings.add(warning);
+    }
+
+    clearWarnings(): void {
+        this._warnings.clear();
+    }
+
+    addElement(element: Element): boolean {
         const contained = this._elements.some(
             (item) => item.label === element.label
         );
         if (contained) {
-            return;
+            return false;
         }
 
         this._elements.push(element);
+        return true;
     }
 
-    addArc(arc: Arc): void {
+    addArc(arc: Arc): boolean {
         const contained = this._arcs.some(
             (item) => item.source === arc.source && item.target === arc.target
         );
         if (contained) {
-            return;
+            return false;
         }
 
         this._arcs.push(arc);
+        return true;
     }
 
     isEmpty(): boolean {
         return this.arcs.length + this.elements.length === 0;
+    }
+    /**
+     * set reference from arcs to transitions and vice versa
+     * @returns all references found?
+     */
+    setRefs(): boolean {
+        let check = true;
+        this.elements.forEach((e) => {
+            e.resetArcs();
+        });
+
+        this.arcs.forEach((a) => {
+            const source = this.elements.find((e) => e.label == a.source);
+            const target = this.elements.find((e) => e.label == a.target);
+
+            if (source) {
+                a.sourceEl = source;
+                source.addOutgoingArc(a);
+            } else {
+                check = false;
+            }
+
+            if (target) {
+                a.targetEl = target;
+                target.addIncomingArc(a);
+            } else {
+                check = false;
+            }
+        });
+
+        return check;
     }
 }
 
 export type Arc = {
     source: string;
     target: string;
+    sourceEl: Element | null;
+    targetEl: Element | null;
 };

--- a/src/app/services/display.service.ts
+++ b/src/app/services/display.service.ts
@@ -35,13 +35,14 @@ export class DisplayService implements OnDestroy {
         return this._runs;
     }
 
-    public addEmptyRun(): void {
+    public addEmptyRun(): Run {
         this.registerRun(new Run());
+        return this.currentRun;
     }
 
     public registerRun(run: Run): void {
         //add run or update current run if empty
-        if (this.currentRun.isEmpty()) {
+        if (this.currentRun.isEmpty() && this.runs.length > 0) {
             this.updateCurrentRun(run);
         } else {
             this.runs.push(run);
@@ -53,13 +54,17 @@ export class DisplayService implements OnDestroy {
         return this.runs.indexOf(run);
     }
 
+    public getCurrentRunIndex(): number {
+        return this.runs.indexOf(this.currentRun);
+    }
+
     public updateCurrentRun(run: Run): void {
-        const index = this.getRunIndex(this.currentRun);
+        const index = this.getCurrentRunIndex();
         this.runs[index] = run;
         this.display(run);
     }
 
-    public removeRun(run: Run): void {
+    public removeRun(run: Run): Run {
         const index = this.getRunIndex(run);
         if (index > -1) {
             this.runs.splice(index, 1);
@@ -70,14 +75,46 @@ export class DisplayService implements OnDestroy {
         } else {
             this.addEmptyRun(); //create new empty run
         }
+
+        return this.currentRun;
     }
 
-    public removeCurrentRun(): void {
-        this.removeRun(this.currentRun);
+    public removeCurrentRun(): Run {
+        return this.removeRun(this.currentRun);
     }
 
     public clearRuns(): void {
         this.runs.splice(0, this.runs.length);
         this.addEmptyRun();
+    }
+
+    public hasPreviousRun(): boolean {
+        return this.getCurrentRunIndex() > 0;
+    }
+
+    public hasNextRun(): boolean {
+        return this.getCurrentRunIndex() < this.runs.length - 1;
+    }
+
+    public isCurrentRunEmpty(): boolean {
+        return this.currentRun.isEmpty();
+    }
+
+    public setNextRun(): Run {
+        const index = this.getCurrentRunIndex();
+        if (this.runs.length - 1 > index) {
+            this.display(this.runs[index + 1]);
+        }
+
+        return this.currentRun;
+    }
+
+    public setPreviousRun(): Run {
+        const index = this.getCurrentRunIndex();
+        if (index > 0) {
+            this.display(this.runs[index - 1]);
+        }
+
+        return this.currentRun;
     }
 }

--- a/src/app/services/parser.service.ts
+++ b/src/app/services/parser.service.ts
@@ -116,8 +116,6 @@ export class ParserService {
                                 !run.addArc({
                                     source: splitLine[0],
                                     target: splitLine[1],
-                                    sourceEl: null,
-                                    targetEl: null,
                                 })
                             ) {
                                 run.addWarning(

--- a/src/app/services/parser.service.ts
+++ b/src/app/services/parser.service.ts
@@ -14,14 +14,18 @@ const arcsAttribute = '.arcs';
 export class ParserService {
     constructor(private toastr: ToastrService) {}
 
-    // TODO: More validation (see PAR-10)
-    parse(content: string): Run | null {
+    parse(content: string, errors: Set<string>): Run | null {
         const contentLines = content.split('\n');
         const run: Run = new Run();
 
         let currentParsingState: ParsingStates = 'initial';
         let fileContainsTransitions = false;
         let fileContainsArcs = false;
+
+        this.toastr.toasts.forEach((t) => {
+            this.toastr.remove(t.toastId);
+        });
+
         for (const line of contentLines) {
             const trimmedLine = line.trim();
 
@@ -33,6 +37,7 @@ export class ParserService {
                         currentParsingState = 'type';
                         break;
                     } else {
+                        errors.add(`The type of the file has to be 'ps'`);
                         this.toastr.error(
                             `The type of the file has to be 'ps'`,
                             `Unable to parse file`
@@ -51,8 +56,9 @@ export class ParserService {
                         fileContainsArcs = true;
                         break;
                     } else {
+                        errors.add(`The file contains invalid parts`);
                         this.toastr.error(
-                            `The file contains unvalid parts`,
+                            `The file contains invalid parts`,
                             `Unable to parse file`
                         );
                         return null;
@@ -65,18 +71,34 @@ export class ParserService {
                         break;
                     } else if (trimmedLine !== arcsAttribute) {
                         if (trimmedLine.split(' ').length !== 1) {
+                            run.addWarning(
+                                `Transition names are not allow to contain blank`
+                            );
                             this.toastr.warning(
                                 `Transition names are not allow to contain blank`,
                                 `Only first word is used`
                             );
                         }
-                        run.addElement(new Element(trimmedLine.split(' ')[0]));
+                        if (
+                            !run.addElement(
+                                new Element(trimmedLine.split(' ')[0])
+                            )
+                        ) {
+                            run.addWarning(
+                                `File contains duplicate transitions`
+                            );
+                            this.toastr.warning(
+                                `File contains duplicate transitions`,
+                                `Duplicate transitions are ingnored`
+                            );
+                        }
                         break;
                     } else if (trimmedLine === '.arcs') {
                         currentParsingState = 'arcs';
                         fileContainsArcs = true;
                         break;
                     } else {
+                        errors.add(`Unable to parse file`);
                         this.toastr.error(`Error`, `Unable to parse file`);
                         return null;
                     }
@@ -86,11 +108,22 @@ export class ParserService {
                     } else if (trimmedLine !== '.transitions') {
                         if (trimmedLine.split(' ').length === 2) {
                             const splitLine = trimmedLine.split(' ');
-                            run.addArc({
-                                source: splitLine[0],
-                                target: splitLine[1],
-                            });
+                            if (
+                                !run.addArc({
+                                    source: splitLine[0],
+                                    target: splitLine[1],
+                                    sourceEl: null,
+                                    targetEl: null,
+                                })
+                            ) {
+                                run.addWarning(`File contains duplicate arcs`);
+                                this.toastr.warning(
+                                    `File contains duplicate arcs`,
+                                    `Duplicate arcs are ingnored`
+                                );
+                            }
                         } else {
+                            run.addWarning(`File contains invalid arcs`);
                             this.toastr.warning(
                                 `File contains invalid arcs`,
                                 `Invalid arcs are ingnored`
@@ -102,14 +135,25 @@ export class ParserService {
                         fileContainsTransitions = true;
                         break;
                     } else {
+                        errors.add(`Unable to parse file`);
                         this.toastr.error(`Error`, `Unable to parse file`);
                         return null;
                     }
             }
         }
         if (fileContainsTransitions && fileContainsArcs) {
+            if (!run.setRefs()) {
+                run.addWarning(
+                    `File contains arcs for non existing transitions`
+                );
+                this.toastr.warning(
+                    `File contains arcs for non existing transitions`,
+                    `Invalid arcs are ingnored`
+                );
+            }
             return run;
         } else {
+            errors.add(`File does not contain transitions and arcs`);
             this.toastr.error(
                 `File does not contain transitions and arcs`,
                 `Unable to parse file`

--- a/src/app/services/parser.service.ts
+++ b/src/app/services/parser.service.ts
@@ -18,6 +18,8 @@ export class ParserService {
         const contentLines = content.split('\n');
         const run: Run = new Run();
 
+        run.setText(content);
+
         let currentParsingState: ParsingStates = 'initial';
         let fileContainsTransitions = false;
         let fileContainsArcs = false;
@@ -85,7 +87,9 @@ export class ParserService {
                             )
                         ) {
                             run.addWarning(
-                                `File contains duplicate transitions`
+                                `File contains duplicate transition (${
+                                    trimmedLine.split(' ')[0]
+                                })`
                             );
                             this.toastr.warning(
                                 `File contains duplicate transitions`,
@@ -116,7 +120,9 @@ export class ParserService {
                                     targetEl: null,
                                 })
                             ) {
-                                run.addWarning(`File contains duplicate arcs`);
+                                run.addWarning(
+                                    `File contains duplicate arc (${splitLine[0]} ${splitLine[1]})`
+                                );
                                 this.toastr.warning(
                                     `File contains duplicate arcs`,
                                     `Duplicate arcs are ingnored`
@@ -151,6 +157,8 @@ export class ParserService {
                     `Invalid arcs are ingnored`
                 );
             }
+
+            //Todo check circles in run
             return run;
         } else {
             errors.add(`File does not contain transitions and arcs`);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,6 +1,11 @@
 /* You can add global styles to this file, and also import other style files */
 @import '~ngx-toastr/toastr';
 
+
+:root {
+    --success-color: #4CAF50;
+}
+
 html { height: 100%; }
 body {
     margin: 0;


### PR DESCRIPTION
Fehler/Warnungen bei der Validierung eines Runs werden am Textfeld angezeigt (Icon + Tooltip).
Es werden keine doppelten Fehler/Warnungen angezeigt und vor einem neuen Parsen werden bestehende Fehler/Warnungen gelöscht.
Warnungen werden am Run selbst gespeichert, damit diese nachher beim Durchschalten der Runs erhalten bleiben.
Zusätzliche Warnmeldungen, wenn ein Arc oder Transition doppelt vorkommen.
Die Referenzierung von Transitions in Arcs wird überprüft und bei nicht vorhandenen Transitions eine Warnmeldung angezeigt (Die Prüfung der Referenzierung wird nachher auch für den Sugiyama benötigt)
