### PR TITLE
Update Parser + Sugiyama

### DIFF
--- a/src/app/classes/diagram/arc.ts
+++ b/src/app/classes/diagram/arc.ts
@@ -8,4 +8,5 @@ export type Breakpoint = {
     x: number;
     y: number;
     arc: Arc;
+    layerPos?: number;
 };

--- a/src/app/classes/diagram/element.ts
+++ b/src/app/classes/diagram/element.ts
@@ -6,4 +6,5 @@ export interface Element {
     label: string;
     incomingArcs: Arc[];
     outgoingArcs: Arc[];
+    layerPos?: number;
 }

--- a/src/app/classes/diagram/functions/run-helper.fn.ts
+++ b/src/app/classes/diagram/functions/run-helper.fn.ts
@@ -25,7 +25,7 @@ export function generateTextForRun(run: Run): string {
     const lines = [typeKey];
     lines.push(transitionsAttribute);
     run.elements.forEach((e) => {
-        if (e.x && e.y) lines.push(`${e.label} [${e.x}, ${e.y}]`);
+        if (e.layerPos) lines.push(`${e.label} [${e.layerPos}]`);
         else lines.push(e.label);
     });
 
@@ -53,7 +53,7 @@ function getBreakpointInfo(arc: Arc): string {
     if (arc.breakpoints.length > 0) {
         text = '';
         arc.breakpoints.forEach((breakpoint) => {
-            text += `[${breakpoint.x + 25}, ${breakpoint.y + 25}]`;
+            text += `[${breakpoint.layerPos}]`;
         });
     }
 

--- a/src/app/services/layout.service.spec.ts
+++ b/src/app/services/layout.service.spec.ts
@@ -59,6 +59,7 @@ describe('LayoutService', () => {
                 {
                     incomingArcs: [],
                     label: 't1',
+                    layerPos: 0,
                     outgoingArcs: [
                         {
                             breakpoints: [],
@@ -78,6 +79,7 @@ describe('LayoutService', () => {
                         },
                     ],
                     label: 't2',
+                    layerPos: 0,
                     outgoingArcs: [
                         {
                             breakpoints: [],
@@ -107,6 +109,7 @@ describe('LayoutService', () => {
                         },
                     ],
                     label: 't3',
+                    layerPos: 0,
                     outgoingArcs: [],
                     x: 600,
                     y: 160,
@@ -120,6 +123,7 @@ describe('LayoutService', () => {
                         },
                     ],
                     label: 't4',
+                    layerPos: 0,
                     outgoingArcs: [
                         {
                             breakpoints: [
@@ -127,9 +131,11 @@ describe('LayoutService', () => {
                                     arc: expect.anything(),
                                     x: 400,
                                     y: 80,
+                                    layerPos: 0,
                                 },
                                 {
                                     arc: expect.anything(),
+                                    layerPos: 0,
                                     x: 500,
                                     y: 40,
                                 },
@@ -155,11 +161,13 @@ describe('LayoutService', () => {
                         },
                     ],
                     label: 't5',
+                    layerPos: 1,
                     outgoingArcs: [
                         {
                             breakpoints: [
                                 {
                                     arc: expect.anything(),
+                                    layerPos: 2,
                                     x: 500,
                                     y: 280,
                                 },
@@ -185,6 +193,7 @@ describe('LayoutService', () => {
                         },
                     ],
                     label: 't6',
+                    layerPos: 1,
                     outgoingArcs: [
                         {
                             breakpoints: [],

--- a/src/app/services/parser/parser.service.ts
+++ b/src/app/services/parser/parser.service.ts
@@ -22,13 +22,9 @@ type ParsingStates = 'initial' | 'type' | 'transitions' | 'arcs';
 })
 export class ParserService {
     constructor(private toastr: ToastrService) {}
-    static transitionRegex = new RegExp(
-        '^([^\\[ ]+)(\\s?\\[\\d+,\\s?\\d+\\])?$'
-    );
-    static arcRegex = new RegExp(
-        '^([^\\[ ]+)\\s([^\\[ ]+)(\\s?\\[\\d+,\\s?\\d+\\])*$'
-    );
-    static breakpointRegex = new RegExp('\\[\\d+,\\s?\\d+\\]');
+    static transitionRegex = new RegExp('^([^\\[ ]+)(\\s?\\[\\d+\\])?$');
+    static arcRegex = new RegExp('^([^\\[ ]+)\\s([^\\[ ]+)(\\s?\\[\\d+\\])*$');
+    static breakpointRegex = new RegExp('\\[\\d+\\]');
 
     parse(content: string, errors: Set<string>): Run | null {
         const contentLines = content.split('\n');
@@ -92,8 +88,7 @@ export class ParserService {
                         break;
                     } else if (trimmedLine !== arcsAttribute) {
                         let label: string;
-                        let posX: number | undefined;
-                        let posY: number | undefined;
+                        let layerPos: number | undefined;
                         if (!ParserService.transitionRegex.test(trimmedLine)) {
                             label = trimmedLine.split(' ')[0];
                             run.warnings.push(`Invalid transition definition`);
@@ -108,15 +103,9 @@ export class ParserService {
                                 label = match[1];
                                 if (match[2]) {
                                     //extract coordinates
-                                    posX = parseInt(
+                                    layerPos = parseInt(
                                         match[2].substring(
                                             match[2].indexOf('[') + 1,
-                                            match[2].indexOf(',')
-                                        )
-                                    );
-                                    posY = parseInt(
-                                        match[2].substring(
-                                            match[2].indexOf(',') + 1,
                                             match[2].indexOf(']')
                                         )
                                     );
@@ -129,8 +118,7 @@ export class ParserService {
                         if (
                             !addElement(run, {
                                 label: label,
-                                x: posX,
-                                y: posY,
+                                layerPos: layerPos,
                                 incomingArcs: [],
                                 outgoingArcs: [],
                             })
@@ -202,27 +190,16 @@ export class ParserService {
                                             trimmedLineTmp
                                         )
                                     ) {
-                                        const posX =
-                                            parseInt(
-                                                trimmedLineTmp.substring(
-                                                    trimmedLineTmp.indexOf(
-                                                        '['
-                                                    ) + 1,
-                                                    trimmedLineTmp.indexOf(',')
-                                                )
-                                            ) - 25; // center breakpoints
-                                        const posY =
-                                            parseInt(
-                                                trimmedLineTmp.substring(
-                                                    trimmedLineTmp.indexOf(
-                                                        ','
-                                                    ) + 1,
-                                                    trimmedLineTmp.indexOf(']')
-                                                )
-                                            ) - 25; // center breakpoints
+                                        const layerPos = parseInt(
+                                            trimmedLineTmp.substring(
+                                                trimmedLineTmp.indexOf('[') + 1,
+                                                trimmedLineTmp.indexOf(']')
+                                            )
+                                        );
                                         breakpoints.push({
-                                            x: posX,
-                                            y: posY,
+                                            x: 0,
+                                            y: 0,
+                                            layerPos: layerPos,
                                             arc: arc,
                                         });
                                         trimmedLineTmp =


### PR DESCRIPTION
Es werden jetzt keine Koordinaten (X,Y) sondern die Position im Layer verarbeitet (Parser+Layout).
Die Position kann an Transitions und an Arcs für die Breakpoints angegeben werden.
Haben zwei Elemente auf gleicher Ebene die gleiche fixe Position, wird eine davon ignoriert.
Ist die Position größer als die maximal mögliche im Layer, wird das Element an die letzte mögliche Position gesetzt.
Positionen <1 werden ignoriert. So kann z.B. per [0][2] nur der 2. Breakpoint eines Arcs eine feste Position erhalten.

Alle Elemente mit fixer Position werden beim Sugiyama nicht mehr verschoben. Die übrigen Elemente werden auf die noch freien Positionen aufgeteilt.