### PR TITLE
in the merge view the run was not centered (because of the additional hightlight color area i guess)

### DIFF
--- a/src/app/components/display-merged-run/display-merged-run.component.ts
+++ b/src/app/components/display-merged-run/display-merged-run.component.ts
@@ -131,7 +131,7 @@ export class DisplayMergedRunComponent
                         this.layoutService.centerRuns(
                             [modifiedRun],
                             w / 2,
-                            h / 2
+                            h / 2 + 40
                         );
                 }
                 return this.svgService.createSvgElements(


### PR DESCRIPTION
added something to the y value that our example prime event structure is not cut off.